### PR TITLE
Version 0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "creative-cloud-libraries",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Reverting parliament back to 2.11.0 due to 404's from links. 
It appears that links with the url such as: `https://www.adobe.io/creative-cloud-libraries/docs` are missing the trailing slash and thus results in a 404. 

Hopefully this fixes that as the changes to links seem to have been added in the 2.12.1 parliament update. 